### PR TITLE
allow to lint \input commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ LABEL "repository"="http://github.com/j2kun/chktex-action"
 LABEL "homepage"="http://github.com/j2kun"
 LABEL "maintainer"="Jeremy Kun <j2kun@users.noreply.github.com>"
 
-RUN apt update
-RUN apt install -y chktex python3.7 python3-pip
+RUN apt-get update && apt-get install -y \
+  chktex \
+  python3.7 \
+  python3-pip
 
 WORKDIR /tmp/action
 COPY requirements.txt ./

--- a/run_action.py
+++ b/run_action.py
@@ -1,3 +1,5 @@
+"""Find all *tex files and run chktex on them"""
+
 import os
 import subprocess
 import sys
@@ -12,6 +14,7 @@ if not GITHUB_WORKSPACE:
 
 
 def main():
+    """main function"""
     os.chdir(GITHUB_WORKSPACE)
 
     all_files_in_tree = []
@@ -34,21 +37,30 @@ def main():
             print(filename)
         sys.exit(0)
 
-    num_linter_errors = 0
+    files_with_errors = 0
 
     for filename in files_to_process:
-        print("Linting %s\n" % filename)
+        print(f"Linting {filename}", end="\n\n")
+
+        directory = os.path.dirname(filename)
+
+        # run process inside the file's folder
         completed_process = subprocess.run(
-            ["chktex", "-q", filename], capture_output=True, text=True, check=False
+            ["chktex", "-q", filename],
+            cwd=directory,
+            capture_output=True,
+            text=True,
+            check=False,
         )
         stdout = completed_process.stdout
 
         if stdout:
-            num_linter_errors += 1
+            files_with_errors += 1
             print(stdout)
+        else:
+            print("No warnings found", end="\n\n")
 
-    if num_linter_errors > 0:
-        sys.exit(1)
+    sys.exit(files_with_errors)
 
 
 if __name__ == "__main__":

--- a/run_action.py
+++ b/run_action.py
@@ -12,10 +12,19 @@ if not GITHUB_WORKSPACE:
     print("No GITHUB_WORKSPACE environment variable set.")
     sys.exit(1)
 
+os.chdir(GITHUB_WORKSPACE)
+
+
+CHKTEXRC = os.path.abspath(".chktexrc")
+if os.path.exists(CHKTEXRC):
+    print("found local chktexrc")
+    CHKTEX_COMMAND = lambda file: ["chktex", "-q", "-l", CHKTEXRC, file]
+else:
+    CHKTEX_COMMAND = lambda file: ["chktex", "-q", file]
+
 
 def main():
     """main function"""
-    os.chdir(GITHUB_WORKSPACE)
 
     all_files_in_tree = []
     for root, dirs, files in os.walk(".", topdown=True):
@@ -23,43 +32,50 @@ def main():
             if skip_dir in dirs:
                 dirs.remove(skip_dir)
 
-        for filename in files:
-            all_files_in_tree.append(os.path.join(root, filename))
+        for file in files:
+            all_files_in_tree.append(os.path.join(root, file))
 
-    files_to_process = [
-        filename for filename in all_files_in_tree if filename.endswith(".tex")
-    ]
+    files_to_process = [file for file in all_files_in_tree if file.endswith(".tex")]
 
     if not files_to_process:
         print("Found no .tex files to process")
         print("Complete tree found:")
-        for filename in all_files_in_tree:
-            print(filename)
+        for file in all_files_in_tree:
+            print(file)
         sys.exit(0)
 
     files_with_errors = 0
 
-    for filename in files_to_process:
-        print(f"Linting {filename}", end="\n\n")
+    for file in files_to_process:
+        print(f"Linting {file}")
 
-        directory = os.path.dirname(filename)
+        directory = os.path.dirname(file)
+        relative_file = os.path.basename(file)
 
         # run process inside the file's folder
         completed_process = subprocess.run(
-            ["chktex", "-q", filename],
+            CHKTEX_COMMAND(relative_file),
             cwd=directory,
             capture_output=True,
             text=True,
             check=False,
         )
         stdout = completed_process.stdout
+        stderr = completed_process.stderr
 
         if stdout:
             files_with_errors += 1
-            print(stdout)
-        else:
-            print("No warnings found", end="\n\n")
+            print(
+                "----------------------------------------",
+                stdout,
+                "----------------------------------------",
+                sep="\n",
+            )
 
+        if stderr:
+            print("chktex run into errors:", stderr, sep="\n")
+
+    print(f"found {files_with_errors} files with errors")
     sys.exit(files_with_errors)
 
 

--- a/run_action.py
+++ b/run_action.py
@@ -2,45 +2,54 @@ import os
 import subprocess
 import sys
 
-SKIP_DIRS = set(['venv', '.git', '__pycache__'])
+SKIP_DIRS = set(["venv", ".git", "__pycache__"])
 
 
-GITHUB_WORKSPACE = os.environ.get('GITHUB_WORKSPACE')
+GITHUB_WORKSPACE = os.environ.get("GITHUB_WORKSPACE")
 if not GITHUB_WORKSPACE:
     print("No GITHUB_WORKSPACE environment variable set.")
     sys.exit(1)
 
-os.chdir(GITHUB_WORKSPACE)
 
-all_files_in_tree = []
-for root, dirs, files in os.walk(".", topdown=True):
-    for d in SKIP_DIRS:
-        if d in dirs:
-            dirs.remove(d)
+def main():
+    os.chdir(GITHUB_WORKSPACE)
 
-    for filename in files:
-        all_files_in_tree.append(os.path.join(root, filename))
+    all_files_in_tree = []
+    for root, dirs, files in os.walk(".", topdown=True):
+        for skip_dir in SKIP_DIRS:
+            if skip_dir in dirs:
+                dirs.remove(skip_dir)
 
-files_to_process = [filename for filename in all_files_in_tree if filename.endswith(".tex")]
+        for filename in files:
+            all_files_in_tree.append(os.path.join(root, filename))
 
-if not files_to_process:
-    print("Found no .tex files to process")
-    print("Complete tree found:")
-    for filename in all_files_in_tree:
-        print(filename)
-    sys.exit(0)
+    files_to_process = [
+        filename for filename in all_files_in_tree if filename.endswith(".tex")
+    ]
+
+    if not files_to_process:
+        print("Found no .tex files to process")
+        print("Complete tree found:")
+        for filename in all_files_in_tree:
+            print(filename)
+        sys.exit(0)
+
+    num_linter_errors = 0
+
+    for filename in files_to_process:
+        print("Linting %s\n" % filename)
+        completed_process = subprocess.run(
+            ["chktex", "-q", filename], capture_output=True, text=True, check=False
+        )
+        stdout = completed_process.stdout
+
+        if stdout:
+            num_linter_errors += 1
+            print(stdout)
+
+    if num_linter_errors > 0:
+        sys.exit(1)
 
 
-num_linter_errors = 0
-
-for filename in files_to_process:
-    print("Linting %s\n" % filename)
-    completed_process = subprocess.run(["chktex", "-q", filename], capture_output=True, text=True, check=False)
-    stdout = completed_process.stdout
-
-    if stdout:
-        num_linter_errors += 1
-        print(stdout)
-
-if num_linter_errors > 0:
-    sys.exit(1)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hello!

We've been using your action for a project we're working on, and I realized that to lint files with \input commands chktex (with the -I switch on) needs to be in the linted file's directory. 

I've implemented this functionality through the subprocess.run cwd parameter, and would love to contribute to your work.

I have also made some other small aesthetic changes, hope they're fine with you.